### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -332,7 +332,7 @@ python3.10 -m venv qdws-env
 9.  Verify SQDMetal installation:
 
     ```bash
-    python -c "import sqdmetal; print('SQDMetal installed successfully')"
+    python -c "import SQDMetal; print('SQDMetal installed successfully')"
     ```
 
 10. Final verification of all packages:


### PR DESCRIPTION
In Windows installation, verifying SQDMetal installation has error when importing SQDMetal. In the given script it's written as "sqdmetal" but it should have been "SQDMetal".